### PR TITLE
chore: use shared renovate-presets config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,4 @@
 {
-  "extends": [
-    "config:base",
-    ":dependencyDashboard",
-    ":automergeMinor"
-  ],
-  "packageRules": [
-    {
-      "matchPackagePatterns": ["python"],
-      "automerge": false
-    }
-  ]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>dixneuf19/renovate-presets"]
 }


### PR DESCRIPTION
## Summary
- Replace inline Renovate config with shared presets from `dixneuf19/renovate-presets`
- Includes: `config:best-practices`, automerge minor/patch, 3-day release cooldown, OSV vulnerability alerts, Python Docker image manual review

🤖 Generated with [Claude Code](https://claude.com/claude-code)